### PR TITLE
Fix missing portal hub room when last portal is destroyed.

### DIFF
--- a/ValheimServersideQoL/Processors/PortalHubProcessor.cs
+++ b/ValheimServersideQoL/Processors/PortalHubProcessor.cs
@@ -208,6 +208,7 @@ sealed class PortalHubProcessor : Processor
             foreach (var zdo in PlacedObjects)
                 zdo.Destroy();
             PlacedObjects.Clear();
+            _lastHubWidth = 0;
             return;
         }
 


### PR DESCRIPTION
Reset _lastHubWidth to 0 when destroying portal hub room. Should fix #175 but I'm not sure how to test locally.