### PR TITLE
Fix Valheim 1.0 compatibility

### DIFF
--- a/ValheimServersideQoL/ExtensionMethods.cs
+++ b/ValheimServersideQoL/ExtensionMethods.cs
@@ -11,9 +11,24 @@ static class ExtensionMethods
 {
     public static ExtendedZDO? GetExtendedZDO(this ZDOMan instance, ZDOID id) => (ExtendedZDO?)instance.GetZDO(id);
 
-    /// <see cref="ZNetScene.InActiveArea(Vector2i, Vector2i)"/>
-    public static int GetActiveArea(this ZoneSystem instance) => instance.m_activeArea - 1;
-    public static int GetLoadedArea(this ZoneSystem instance) => instance.m_activeArea;
+    // 1.0 replaced ZoneSystem's single private m_activeArea int with ZNet's
+    // public SimulationDistance (near/far/total), synced from the server.
+    // Near maps to the old "active" (fully simulated) radius; Total maps to
+    // the old "loaded" (near+far/ghost) radius.
+    public static int GetActiveArea(this ZoneSystem instance) => ZNet.instance.GetSyncedSimulationDistance().NearSimulationDistance;
+    public static int GetLoadedArea(this ZoneSystem instance) => ZNet.instance.GetSyncedSimulationDistance().TotalSimulationDistance;
+
+    // 1.0 changed ZDOMan.FindSectorObjects from (sector, nearDist, farDist,
+    // objects) to (sector, SimulationDistance, nearObjects, farObjects).
+    // Every call site in this codebase only ever passed farDist=0 and only
+    // wants the near list, so this shim preserves every existing call site
+    // unchanged rather than touching each one individually.
+    static readonly List<ZDO> s_discardZdos = [];
+    public static void FindSectorObjects(this ZDOMan instance, Vector2s sector, int distance, int _, List<ZDO> objects)
+    {
+        s_discardZdos.Clear();
+        instance.FindSectorObjects(sector, new SimulationDistance(distance, 0, false), objects, s_discardZdos);
+    }
 
     public static float GetHeight(this Heightmap hmap, Vector3 pos)
     {

--- a/ValheimServersideQoL/Main.cs
+++ b/ValheimServersideQoL/Main.cs
@@ -794,10 +794,10 @@ public sealed partial class Main : BaseUnityPlugin
         {
             var cmd = commands[command];
             if (cmd.GetAction() is { } consoleEvent)
-                consoleEvent(new MyConsoleEventArgs(command, args));
+                consoleEvent(new MyConsoleEventArgs(command, cmd, args));
             else if (cmd.GetActionFailable() is { } consoleEventFailable)
             {
-                var result = consoleEventFailable(new MyConsoleEventArgs(command, args));
+                var result = consoleEventFailable(new MyConsoleEventArgs(command, cmd, args));
                 if (result is not bool b || !b)
                     throw new Exception(result.ToString());
             }
@@ -807,8 +807,8 @@ public sealed partial class Main : BaseUnityPlugin
 
         sealed class MyConsoleEventArgs : ConsoleEventArgs
         {
-            public MyConsoleEventArgs(string command, params string[] args)
-                : base("", null)
+            public MyConsoleEventArgs(string command, Terminal.ConsoleCommand cmd, params string[] args)
+                : base("", null, cmd)
                 => Args = [command, .. args];
         }
     }

--- a/ValheimServersideQoL/ModConfig.TradersConfig.cs
+++ b/ValheimServersideQoL/ModConfig.TradersConfig.cs
@@ -15,7 +15,9 @@ partial record ModConfigBase
 
             return ZNetScene.instance.m_prefabs.Select(static x => x.GetComponent<Trader>()).Where(static x => x is not null)
                 .Select(trader => (Trader: trader, Entries: (IReadOnlyList<(string GlobalKey, ConfigEntry<bool> ConfigEntry)>)[.. trader.m_items
-                .Where(static x => !string.IsNullOrEmpty(x.m_requiredGlobalKey))
+                // 1.0 added trade items with no physical m_prefab (e.g. service/currency-style entries);
+                // this feature is specifically about item-purchase unlocks, so skip those.
+                .Where(static x => !string.IsNullOrEmpty(x.m_requiredGlobalKey) && x.m_prefab is not null)
                 .Select(item => (item.m_requiredGlobalKey, cfg.Bind(section, Invariant($"{nameof(AlwaysUnlock)}{trader.name}{item.m_prefab.name}"), false,
                     Invariant($"Remove the progression requirements for buying {(global::Localization.instance.Localize(item.m_prefab.m_itemData.m_shared.m_name))} from {(global::Localization.instance.Localize(trader.m_name))}"))))]))
                 .Where(static x => x.Entries.Any())

--- a/ValheimServersideQoL/ModConfig.TrophySpawnerConfig.cs
+++ b/ValheimServersideQoL/ModConfig.TrophySpawnerConfig.cs
@@ -11,7 +11,7 @@ partial record ModConfigBase
 
         public ConfigEntry<int> ActivationDelay { get; } = cfg.BindEx(section, 3600, "Time in seconds before trophies start attracting mobs");
         public ConfigEntry<int> RespawnDelay { get; } = cfg.BindEx(section, 12, "Respawn delay in seconds");
-        static float MaxDistance => Mathf.Round(Mathf.Sqrt(2) * ZoneSystem.instance.m_activeArea * ZoneSystem.c_ZoneSize);
+        static float MaxDistance => Mathf.Round(Mathf.Sqrt(2) * ZoneSystem.instance.GetLoadedArea() * ZoneSystem.c_ZoneSize);
         public ConfigEntry<float> MinSpawnDistance { get; } = cfg.BindEx(section, MaxDistance,
             "Min distance from the trophy mobs can spawn", new AcceptableValueRange<float>(0, MaxDistance));
         public ConfigEntry<float> MaxSpawnDistance { get; } = cfg.BindEx(section, MaxDistance,

--- a/ValheimServersideQoL/PrivateAccessor.cs
+++ b/ValheimServersideQoL/PrivateAccessor.cs
@@ -117,13 +117,16 @@ static class PrivateAccessor
 
     public static IReadOnlyDictionary<int, ZoneLocation> GetLocationsByHash(this ZoneSystem instance) => GetLocationsByHashFunc(instance);
 
-    static Func<ZoneSystem, ZoneLocation, int, Vector3, Quaternion, SpawnMode, List<GameObject>, GameObject> SpawnLocationFunc
+    // 1.0 added a trailing `bool cheated = false` parameter to ZoneSystem.SpawnLocation.
+    // Reflection/Expression-tree calls can't rely on C#'s optional-parameter defaults,
+    // so it's passed explicitly as `false` (matching the game's own default) below.
+    static Func<ZoneSystem, ZoneLocation, int, Vector3, Quaternion, SpawnMode, List<GameObject>, bool, GameObject> SpawnLocationFunc
 #if DEBUG
     { get; } =
 #else
     => field ??=
 #endif
-        Expression.Lambda<Func<ZoneSystem, ZoneLocation, int, Vector3, Quaternion, SpawnMode, List<GameObject>, GameObject>>(
+        Expression.Lambda<Func<ZoneSystem, ZoneLocation, int, Vector3, Quaternion, SpawnMode, List<GameObject>, bool, GameObject>>(
         Expression.Call(
             Expression.Parameter(typeof(ZoneSystem)) is var par1 ? par1 : throw new Exception(),
             typeof(ZoneSystem).GetMethod("SpawnLocation", AccessFlags | BindingFlags.Instance),
@@ -132,11 +135,12 @@ static class PrivateAccessor
             Expression.Parameter(typeof(Vector3)) is var par4 ? par4 : throw new Exception(),
             Expression.Parameter(typeof(Quaternion)) is var par5 ? par5 : throw new Exception(),
             Expression.Parameter(typeof(SpawnMode)) is var par6 ? par6 : throw new Exception(),
-            Expression.Parameter(typeof(List<GameObject>)) is var par7 ? par7 : throw new Exception()),
-        par1, par2, par3, par4, par5, par6, par7).Compile();
+            Expression.Parameter(typeof(List<GameObject>)) is var par7 ? par7 : throw new Exception(),
+            Expression.Parameter(typeof(bool)) is var par8 ? par8 : throw new Exception()),
+        par1, par2, par3, par4, par5, par6, par7, par8).Compile();
 
     public static GameObject SpawnLocation(this ZoneSystem instance, ZoneLocation location, int seed, Vector3 pos, Quaternion rot, SpawnMode mode, List<GameObject>? spawnedGhostObjects = null)
-        => SpawnLocationFunc(instance, location, seed, pos, rot, mode, spawnedGhostObjects ?? []);
+        => SpawnLocationFunc(instance, location, seed, pos, rot, mode, spawnedGhostObjects ?? [], false);
 
     static Action<ZoneSystem, long> SendGlobalKeysAction
 #if DEBUG

--- a/ValheimServersideQoL/Processors/CreatureLevelUpProcessor.cs
+++ b/ValheimServersideQoL/Processors/CreatureLevelUpProcessor.cs
@@ -331,7 +331,7 @@ sealed class CreatureLevelUpProcessor : Processor
             return;
 
         var maxLevel = spawnData.MaxLevel + increase;
-        var chance = SpawnSystem.GetLevelUpChance(spawnData.LevelUpChance);
+        var chance = SpawnSystem.GetLevelUpChance(pos, spawnData.LevelUpChance);
         var steps = maxLevel - spawnData.MinLevel;
         if (steps is not 0)
         {

--- a/ValheimServersideQoL/Processors/PlayerSpawnedProcessor.cs
+++ b/ValheimServersideQoL/Processors/PlayerSpawnedProcessor.cs
@@ -243,7 +243,7 @@ sealed class PlayerSpawnedProcessor : Processor
                 continue;
 
             if (list[0].GetOwner() == data.m_senderPeerID &&
-                ZNetScene.InActiveArea(list[0].GetSector(), _lastSummoningPlayer.PlayerZDO.GetSector()))
+                ZNetScene.InActiveArea(_lastSummoningPlayer.PlayerZDO.GetPosition(), list[0].GetSector()))
             {
                 RPC.Damage(list[0], new(float.MaxValue) { m_attacker = _lastSummoningPlayer.PlayerZDO.m_uid });
             }

--- a/ValheimServersideQoL/Processors/PortalProcessor.cs
+++ b/ValheimServersideQoL/Processors/PortalProcessor.cs
@@ -110,7 +110,7 @@ sealed class PortalProcessor : Processor
                 if (Utils.DistanceSqr(state.PortalPosition, state.Player.GetPosition()) > _rangeSqr)
                 {
                     if (state.Container.GetOwner() == state.Player.GetOwner() &&
-                        ZNetScene.InActiveArea(state.Container.GetSector(), state.Player.GetSector()))
+                        ZNetScene.InActiveArea(state.Player.GetPosition(), state.Container.GetSector()))
                     {
                         var now = DateTimeOffset.UtcNow;
                         if (now > state.NextRequest)
@@ -163,7 +163,7 @@ sealed class PortalProcessor : Processor
                 {
                     state.NextRequest = now.AddMilliseconds(200);
                     if (state.Container.GetOwner() != state.Player.GetOwner() ||
-                        !ZNetScene.InActiveArea(state.Container.GetSector(), state.Player.GetSector()))
+                        !ZNetScene.InActiveArea(state.Player.GetPosition(), state.Container.GetSector()))
                     {
                         state.Container.SetOwnerInternal(state.Player.GetOwner());
                         state.Container.SetPosition(state.Player.GetPosition() with { y = -1000 });

--- a/ValheimServersideQoL/Processors/SharedProcessorState.cs
+++ b/ValheimServersideQoL/Processors/SharedProcessorState.cs
@@ -232,7 +232,7 @@ static class SharedProcessorState
         for (int i = _zoneRoots.Count - 1; i >= 0; i--)
         {
             var (zone, root) = _zoneRoots[i];
-            if (peers.Any(x => ZNetScene.InActiveArea(zone, x.m_refPos)))
+            if (peers.Any(x => ZNetScene.InActiveArea(x.m_refPos, zone)))
                 continue;
 
             //Main.Instance.Logger.DevLog($"Destroying hmap for {zone}");

--- a/ValheimServersideQoL/Processors/TrophyProcessor.cs
+++ b/ValheimServersideQoL/Processors/TrophyProcessor.cs
@@ -200,7 +200,7 @@ sealed class TrophyProcessor : Processor
         if (ShouldAttemptSpawn(state))
         {
             var level = 1;
-            var levelUpChance = Config.TrophySpawner.LevelUpChanceOverride.Value < 0 ? 0 : SpawnSystem.GetLevelUpChance(Config.TrophySpawner.LevelUpChanceOverride.Value);
+            var levelUpChance = Config.TrophySpawner.LevelUpChanceOverride.Value < 0 ? 0 : SpawnSystem.GetLevelUpChance(zdo.GetPosition(), Config.TrophySpawner.LevelUpChanceOverride.Value);
             if (levelUpChance > 0)
             {
                 for (; level < Config.TrophySpawner.MaxLevel.Value; level++)
@@ -229,8 +229,7 @@ sealed class TrophyProcessor : Processor
                 for (stepCount = 0; stepCount < maxStepCount; stepCount++)
                 {
                     var next = pos + (dir * step);
-                    var z = ZoneSystem.GetZone(next);
-                    if (!ZNetScene.InActiveArea(z, zone))
+                    if (!ZNetScene.InActiveArea(next, zone))
                     {
                         stepCount--;
                         break;


### PR DESCRIPTION
## Summary

Valheim 1.0 restructured how "active"/"loaded" area works — `ZoneSystem`'s single private `m_activeArea` int was replaced with `ZNet`'s public `SimulationDistance` (Near/Far/Total, synced from the server) — and changed several dependent APIs to match:

- **`ZDOMan.FindSectorObjects`** changed from `(sector, nearDist, farDist, objects)` to `(sector, SimulationDistance, nearObjects, farObjects)`. Every call site in this codebase only ever passed `farDist=0` and only wants the near list, so `ExtensionMethods.cs` adds a same-signature shim instead of touching each of the 6 call sites individually.
- **`ZNetScene.InActiveArea`** no longer has a `(sector, sector)` overload — only `(Vector3, Vector3)` and `(Vector3, Vector2s /* sector */)`. Fixed each call site to pass a world position on one side instead of two sectors, using whichever side already had a position available.
- **`ZoneSystem.SpawnLocation`** gained a trailing `bool cheated = false` parameter. `PrivateAccessor.cs` calls it via a reflection-built `Expression.Call` delegate (can't rely on C# optional-parameter defaults there), so the delegate's arity needed updating with `false` supplied explicitly.
- **`SpawnSystem.GetLevelUpChance`** now takes a `Vector3` position as its first argument. Fixed both call sites using the already-in-scope creature/trophy position.
- **`ZoneSystem.GetZone`** now returns `Vector2s` (previously `Vector2i`); `TrophyProcessor`'s active-area check was adjusted accordingly.
- **`Terminal.ConsoleEventArgs`**'s constructor gained a required `Terminal.ConsoleCommand` parameter; `Main.cs`'s internal `MyConsoleEventArgs` now threads through the `ConsoleCommand` that's already available at the call site.
- **Trade items with no physical `m_prefab`** (a new category in 1.0 — the `TradeItem` struct also gained `m_buyKey`/`m_incrementKey`/`m_incrementAmount`, suggesting a repeatable-purchase mechanic) caused a `NullReferenceException` in the `AlwaysUnlock` trader config on startup, which is specifically about item-purchase-lock removal. Filtered these out rather than crashing on them.

Without these fixes the server throws a `MissingFieldException`/`NullReferenceException` chain during world load and startup and never comes up with this mod enabled.

## Judgment calls worth double-checking

A few of these didn't have an unambiguous 1:1 replacement, so I made a call and want to flag them explicitly rather than bury them:

- `GetActiveArea()` now returns `NearSimulationDistance` and `GetLoadedArea()` returns `TotalSimulationDistance` (previously two values one apart, derived from the single old `m_activeArea` int).
- `SpawnLocation`'s new `cheated` parameter is hardcoded to `false` at every existing call site.
- `TrophySpawnerConfig.MaxDistance` now uses `GetLoadedArea()` (the larger of the two) rather than `GetActiveArea()`.

If any of these don't match your intent for the mod, happy to adjust — I don't have deep enough familiarity with the intended balance to be fully confident here, just enough to get it running correctly again.

## Test plan

- [x] Built with .NET 9 SDK (`LangVersion=preview`, for the null-conditional-assignment feature already in use in this codebase) against a real Valheim 1.0.7 dedicated server install
- [x] Deployed to a live BepInEx-modded dedicated server (crossplay/PlayFab) running 1.0.7 alongside 7 other mods
- [x] Confirmed all ~33 processors register cleanly on startup
- [x] Confirmed the world (an existing multi-day save, not a fresh one) loads and the server runs with no exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)